### PR TITLE
[interfaces-config] "main exception: cannot find interfaces: eth0" error log avoided

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-ifdown --force eth0
+if [[ $(ifquery --running eth0) ]]; then
+    ifdown --force eth0
+fi
 
 # Check if ZTP DHCP policy has been installed
 if [ -e /etc/network/ifupdown2/policy.d/ztp_dhcp.json ]; then


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

During bootup sometimes, this error log is seen

```
Dec 22 04:26:29 sonic interfaces-config.sh[2546]: error: main exception: cannot find interfaces: eth0 (interface was probably never up ?)
```

This is of non-functional nature and doesn't affect the flow.

#### How I did it

#### How to verify it

Verified during reboot. Log did not appear and IP was acquired on eth0 as expected

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

